### PR TITLE
User story 6

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -19,4 +19,16 @@ class Api::V1::FavoritesController < ApplicationController
     end
   end
 
+  def destroy
+    user = User.find_by(api_key: params[:api_key])
+    if params[:api_key] && user
+      favorite = Favorite.find_by(location: params[:location])
+      favorite.destroy
+      render json: favorite
+    else
+      render json: {}, status: 401
+    end
+
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :users, only: [:create]
       resources :sessions, only: [:new, :create, :destroy]
       resources :favorites, only: [:create, :index]
+      delete '/favorites', to: "favorites#destroy"
     end
   end
 

--- a/spec/requests/api/v1/favorites_request_spec.rb
+++ b/spec/requests/api/v1/favorites_request_spec.rb
@@ -36,7 +36,7 @@ describe 'favorites endpoint' do
     get "/api/v1/favorites?api_key=#{user.api_key}"
     expect(response).to be_successful
     parsed_list = JSON.parse(response.body, symbolize_names: true)
-    expect(parsed_list[:data][0]][:attributes][:location]).to eq('miami,fl')
+    expect(parsed_list[:data][0][:attributes][:location]).to eq('miami,fl')
     expect(parsed_list[:data][1][:attributes][:location]).to eq('denver,co')
     expect(parsed_list[:data][1][:attributes][:current_weather][:summary].class).to eq(String)
   end
@@ -51,6 +51,19 @@ describe 'favorites endpoint' do
     post "/api/v1/favorites"
 
     expect(status).to be(401)
+  end
+
+  it 'can delete a favorite and return the deleted item' do
+    key = SecureRandom.urlsafe_base64
+    email = Faker::Internet.email
+    user = User.create(email: email, password: "password", api_key: key)
+    post "/api/v1/favorites?location=miami,fl&api_key=#{key}"
+    post "/api/v1/favorites?location=denver,co&api_key=#{key}"
+    delete "/api/v1/favorites?location=miami,fl&api_key=#{key}"
+
+    expect(response).to be_successful
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed_response[:location]).to eq("miami,fl")
   end
 
 end


### PR DESCRIPTION
[x] Completed

DELETE /api/v1/favorites
Content-Type: application/json
Accept: application/json

body:

{
  "location": "Denver, CO", # If you decide to store cities in your database you can send an id if you prefer
  "api_key": "jgn983hy48thw9begh98h4539h4"
}
Requirements:

API key must be sent
If no API key or an incorrect key is provided return 401 (Unauthorized)
Response:

status: 200
body:
[
  {
    "location": "Denver, CO",
    "current_weather": {
      # This can vary but try to keep it consistent with the
      # structure of the response from the /forecast endpoint
    },
    "location": "Golden, CO",
    "current_weather": {
       {...}
    }
  }
]